### PR TITLE
Fix an error accessing the twitter returned auth object

### DIFF
--- a/zinnia_twitter/management/commands/get_twitter_access.py
+++ b/zinnia_twitter/management/commands/get_twitter_access.py
@@ -27,5 +27,5 @@ class Command(NoArgsCommand):
         verifier = raw_input('PIN: ').strip()
         auth.get_access_token(verifier)
 
-        print("ACCESS_KEY = '%s'" % auth.access_token.key)
-        print("ACCESS_SECRET = '%s'" % auth.access_token.secret)
+        print("ACCESS_KEY = '%s'" % auth.access_token)
+        print("ACCESS_SECRET = '%s'" % auth.access_token_secret)


### PR DESCRIPTION
Running get_twitter_access I received this error:

```
  File "/Users/rob/code/training-wheels/env/lib/python2.7/site-packages/zinnia_twitter/management/commands/get_twitter_access.py", line 31, in handle_noargs
    print("ACCESS_KEY = '%s'" % auth.access_token.key)
AttributeError: 'unicode' object has no attribute 'key'
```

Running it in the debugger it looks like the return value may have changed:

```
(Pdb) pprint.pprint(auth.__dict__)
{'access_token': u'XXXXX',
 'access_token_secret': u'XXXXX',
 'callback': None,
 'consumer_key': 'XXXXX',
 'consumer_secret': 'XXXXX',
 'oauth': <requests_oauthlib.oauth1_session.OAuth1Session object at 0x10951b850>,
 'request_token': {u'oauth_callback_confirmed': u'true',
                   u'oauth_token': u'XXXXX',
                   u'oauth_token_secret': u'XXXXX'},
 'secure': True,
 'username': None}
```
